### PR TITLE
Prevent page shifting when hovering a checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,13 +67,14 @@
 						<input type="checkbox" id="cheating" onMouseOver="show_cheating()" onMouseOut="hide_cheating()">
 						<label for="cheating" style="padding-left: 0.5em;" onMouseOver="show_cheating()" onMouseOut="hide_cheating()"> Cheating Mode</label>
 					</div>
+					<div style="min-height: 3em">
+						<div id="options-help-cypher">
+							No letters, only barcode. One of the strongest encryption methods on the planet
+						</div>
 
-					<div id="options-help-cypher">
-						No letters, only barcode. One of the strongest encryption methods on the planet
-					</div>
-
-					<div id="options-help-cheating">
-						Theoretically supports all characters, works by selecting a random slice of jerma's face then writing a letter above it
+						<div id="options-help-cheating">
+							Theoretically supports all characters, works by selecting a random slice of jerma's face then writing a letter above it
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Page jitters when hovering a checkbox, figured I could do my part.

Wrapped the text in a div that reserves some space. Still shifts on very narrow screens but its a good compromise.